### PR TITLE
Use buildin DRM_FORMAT_NV12_10 value to compile with vanilla libdrm2

### DIFF
--- a/gst/kms/gstkmsutils.c
+++ b/gst/kms/gstkmsutils.c
@@ -29,6 +29,10 @@
 
 #include <drm_fourcc.h>
 
+#ifndef DRM_FORMAT_NV12_10
+#define DRM_FORMAT_NV12_10	fourcc_code('N', 'A', '1', '2') /* 2x2 subsampled Cr:Cb plane */
+#endif // DRM_FORMAT_NV12_10
+
 #include "gstkmsutils.h"
 
 /* *INDENT-OFF* */

--- a/gst/rkximage/rkx_kmsutils.c
+++ b/gst/rkximage/rkx_kmsutils.c
@@ -29,6 +29,10 @@
 
 #include <drm_fourcc.h>
 
+#ifndef DRM_FORMAT_NV12_10
+#define DRM_FORMAT_NV12_10	fourcc_code('N', 'A', '1', '2') /* 2x2 subsampled Cr:Cb plane */
+#endif // DRM_FORMAT_NV12_10
+
 #include "rkx_kmsutils.h"
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
This would help to overcome the issues like the following on the systems with
vanila drm_fourcc.h

[   81s] libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -Wdate-time -D_FORTIFY_SOURCE=2 -I/usr/include/libdrm -pthread -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/gstreamer-1.0 -I/usr/include/orc-0.4 -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I../../gst-libs -pthread -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -DGST_USE_UNSTABLE_API -DG_THREADS_MANDATORY -DG_DISABLE_DEPRECATED -Wall -Wdeclaration-after-statement -Wvla -Wpointer-arith -Wmissing-declarations -Wmissing-prototypes -Wredundant-decls -Wwrite-strings -Wold-style-definition -Waggregate-return -Winit-self -Wmissing-include-dirs -Waddress -Wno-multichar -Wnested-externs -Werror -g -g -O2 -fdebug-prefix-map=/usr/src/packages/BUILD=. -fstack-protector-strong -Wformat -Werror=format-security -c rkx_kmsutils.c  -fPIC -DPIC -o .libs/libgstrkximage_la-rkx_kmsutils.o
[   81s] rkx_kmsutils.c:41:5: error: 'DRM_FORMAT_NV12_10' undeclared here (not in a function); did you mean 'DRM_FORMAT_NV12'?
[   81s]    { DRM_FORMAT_##fourcc,GST_VIDEO_FORMAT_##fmt }
[   81s]      ^
[   81s] rkx_kmsutils.c:63:3: note: in expansion of macro 'DEF_FMT'
[   81s]    DEF_FMT (NV12_10, P010_10LE),
[   81s]    ^~~~~~~

Signed-off-by: Matwey V. Kornilov <matwey.kornilov@gmail.com>