### PR TITLE
ISP mode 1A

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,6 @@ include $(top_srcdir)/common/coverage/lcov.mak
 
 include $(top_srcdir)/common/cruft.mak
 
-check: check-exports
+check:
 
 all-local: check-cruft

--- a/README.md
+++ b/README.md
@@ -41,8 +41,18 @@ Most of the properties are the same as that of v4l2 transform, below are rockchi
 Most of the properties are the same as that of v4l2src, below are rockchip extend properties:
 * `disable-autoconf` : If false, this plugin will init pad format/selection for isp_subdev/sensor, to make the media pipeline work out-of-box: (default : false)
 * `tuning-xml-path` : tuning xml file, needed by 3A : (default : "/etc/cam_iq.xml")
-* `isp-mode` : "0A" to disable 3A, "2A" to enable AWB/AE, ~~"3A" to enable AWB/AE/AF~~ : (default : "false")
+* `isp-mode` :
+    * "0A" to disable 3A,
+    * "2A" to enable AWB/AE,
+    * ~~"3A" to enable AWB/AE/AF~~,
+    * "1A" similar to "2A", but allow manual exposure (see below)
 * `input-crop` : [Selection-crop](https://01.org/linuxgraphics/gfx-docs/drm/media/uapi/v4l/selection-api-003.html), should be "left"x"top"x"width"x"height": (optional)
+
+In ISP mode "1A", the exposure of the sensor will not be changed and needs to be set manually:
+
+    v4l2-ctl --device /dev/video1 --set-ctrl=exposure=1600
+
+Exposure needs to be chosen carefully to avoid flicker. The 3A engine will take care of analogue and digital gain, as well as AWB, noise filter, etc.
 
 > NOTE: DO NOT RELY ON `disable-autoconf=false`!  
 > This feature is only used to make debug conveniently.  

--- a/gst/rkv4l2/common.c
+++ b/gst/rkv4l2/common.c
@@ -151,6 +151,7 @@ gst_rk_3a_mode_get_type (void)
       {RK_3A_DISABLE, "RK_3A_DISABLE", "0A"},
       {RK_3A_AEAWB, "RK_3A_AEAWB", "2A"},
       {RK_3A_AEAWBAF, "RK_3A_AEAWBAF", "3A"},
+      {RK_3A_MEAWB, "RK_3A_MEAWB", "1A"},
       {0, NULL, NULL}
     };
     rk_3a_mode = g_enum_register_static ("GstRk3AMode", modes_3a);

--- a/gst/rkv4l2/common.h
+++ b/gst/rkv4l2/common.h
@@ -53,6 +53,7 @@ typedef enum
   RK_3A_DISABLE = 0,
   RK_3A_AEAWB = 1,
   RK_3A_AEAWBAF = 2,
+  RK_3A_MEAWB = 3,
 } GstRk3AMode;
 G_END_DECLS
 

--- a/gst/rkv4l2/rkcamsrc/rkisp1/sensor.c
+++ b/gst/rkv4l2/rkcamsrc/rkisp1/sensor.c
@@ -142,7 +142,8 @@ int rkisp1_get_sensor_desc(int fd, rk_aiq_exposure_sensor_descriptor* sensor_des
     return 0;
 }
 
-int rkisp1_apply_sensor_params(int fd, rk_aiq_exposure_sensor_parameters* expParams)
+int rkisp1_apply_sensor_params(int fd, rk_aiq_exposure_sensor_parameters* expParams,
+    int manual_exposure)
 {
     struct v4l2_control ctrl;
     int ret;
@@ -161,12 +162,14 @@ int rkisp1_apply_sensor_params(int fd, rk_aiq_exposure_sensor_parameters* expPar
         ioctl(fd, VIDIOC_S_CTRL, &ctrl);
     }
 
-    memset(&ctrl, 0, sizeof(ctrl));
-    ctrl.id = V4L2_CID_EXPOSURE;
-    ctrl.value = expParams->coarse_integration_time;
-    ret = ioctl(fd, VIDIOC_S_CTRL, &ctrl);
-    if (ret < 0)
-        return -errno;
+    if (!manual_exposure) {
+        memset(&ctrl, 0, sizeof(ctrl));
+        ctrl.id = V4L2_CID_EXPOSURE;
+        ctrl.value = expParams->coarse_integration_time;
+        ret = ioctl(fd, VIDIOC_S_CTRL, &ctrl);
+        if (ret < 0)
+            return -errno;
+    }
 
     if (DEBUG) {
         printf("Sensor AEC: analog_gain_code_global: %d, digital_gain_global: %d, coarse_integration_time: %d\n",

--- a/gst/rkv4l2/rkcamsrc/rkisp1/sensor.h
+++ b/gst/rkv4l2/rkcamsrc/rkisp1/sensor.h
@@ -24,6 +24,6 @@
 #include "rkisp1-lib.h"
 
 int rkisp1_get_sensor_desc(int fd, rk_aiq_exposure_sensor_descriptor* sensor_desc);
-int rkisp1_apply_sensor_params(int fd, rk_aiq_exposure_sensor_parameters* expParams);
+int rkisp1_apply_sensor_params(int fd, rk_aiq_exposure_sensor_parameters* expParams, int manual_exposure);
 
 #endif

--- a/gst/rkv4l2/rkcamsrc/rkisp1/thread.h
+++ b/gst/rkv4l2/rkcamsrc/rkisp1/thread.h
@@ -30,6 +30,8 @@
 #define AF_DISABLE_MODE 1
 /* enable af/awb/ae */
 #define AAA_ENABLE_MODE 2
+/* manual exposure, auto gain, auto white balance */
+#define AAA_MEAWB_MODE 3
 
 #define READY_STATUS 0
 #define RUN_STATUS 1

--- a/gst/rkv4l2/rkcamsrc/rkisp1/v4l2.c
+++ b/gst/rkv4l2/rkcamsrc/rkisp1/v4l2.c
@@ -236,6 +236,8 @@ int rkisp1_3a_core_init(struct RKISP1Core* rkisp1_core, struct rkisp1_params* pa
     rkisp1_core->sensor_desc.isp_output_height = rkisp1_core->sensor_desc.sensor_output_height;
     rkisp1_core->stats_skip = STATS_SKIP;
 
+    rkisp1_core->manual_exposure = (params->mode == AAA_MEAWB_MODE);
+
     return ret;
 
 close_stats:
@@ -484,7 +486,7 @@ int rkisp1_3a_core_process_params(struct RKISP1Core* rkisp1_core)
     }
 
     /* apply sensor */
-    if (rkisp1_apply_sensor_params(rkisp1_core->sensor_fd, &rkisp1_core->aiq_results.aeResults.sensor_exposure)) {
+    if (rkisp1_apply_sensor_params(rkisp1_core->sensor_fd, &rkisp1_core->aiq_results.aeResults.sensor_exposure, rkisp1_core->manual_exposure)) {
         printf("RKISP1: failed to apply sensor params for %d %s.\n",
             errno, strerror(errno));
         return ret;

--- a/gst/rkv4l2/rkcamsrc/rkisp1/v4l2.h
+++ b/gst/rkv4l2/rkcamsrc/rkisp1/v4l2.h
@@ -61,6 +61,9 @@ struct RKISP1Core {
     int cur_frame_id;
     long long cur_time;
     int stats_skip;
+
+    /* user params */
+    int manual_exposure;
 };
 
 int rkisp1_3a_core_init(struct RKISP1Core* rkisp1_core, struct rkisp1_params* params);


### PR DESCRIPTION
This PR adds a new ISP mode called "1A". It is similar to "2A", but the sensor's exposure is not changed, allowing the user to manually set exposure. The 3A core will still set analogue and digital gain, as well as perform AWB, configure de-nosing etc.

As documented, the user can change exposure as follows:

    v4l2-ctl --device /dev/video1 --set-ctrl=exposure=1600